### PR TITLE
Add option to skip creating user and resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,40 +1,44 @@
 provider "aws" {}
 
 resource "aws_iam_user" "default" {
-  name = "${var.name}${var.postfix ? "Account" : ""}"
-  tags = var.tags
+  count = var.create_user ? 1 : 0
+  name  = "${var.name}${var.postfix ? "Account" : ""}"
+  tags  = var.tags
 }
 
 resource "aws_iam_access_key" "default" {
-  user = aws_iam_user.default.name
+  count = var.create_user ? 1 : 0
+  user  = aws_iam_user.default.0.name
 }
 
 resource "aws_iam_user_policy" "default" {
-  count  = var.policy != null ? 1 : 0
+  count  = (var.create_user && var.policy != null) ? 1 : 0
   name   = "${var.name}${var.postfix ? "Policy" : ""}"
-  user   = aws_iam_user.default.name
+  user   = aws_iam_user.default.0.name
   policy = var.policy
 }
 
 resource "aws_iam_user_policy_attachment" "default" {
   for_each = var.policy_arns
 
-  user       = aws_iam_user.default.name
+  user       = aws_iam_user.default.0.name
   policy_arn = each.value
 }
 
 resource "aws_ssm_parameter" "access_key_id" {
+  count  = var.create_user ? 1 : 0
   name   = "/${lower(var.name)}account/credentials/access_key_id"
   type   = "SecureString"
-  value  = aws_iam_access_key.default.id
+  value  = aws_iam_access_key.default.0.id
   key_id = var.kms_key_id
   tags   = var.tags
 }
 
 resource "aws_ssm_parameter" "secret_access_key" {
+  count  = var.create_user ? 1 : 0
   name   = "/${lower(var.name)}account/credentials/secret_access_key"
   type   = "SecureString"
-  value  = aws_iam_access_key.default.secret
+  value  = aws_iam_access_key.default.0.secret
   key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,29 @@
 output "arn" {
-  value       = aws_iam_user.default.arn
+  value       = aws_iam_user.default.0.arn
   description = "The user ARN"
 }
 
 output "name" {
-  value       = aws_iam_user.default.name
+  value       = aws_iam_user.default.0.name
   description = "The user name"
 }
 
 output "access_key_id" {
-  value       = aws_iam_access_key.default.id
+  value       = aws_iam_access_key.default.0.id
   description = "The access key ID"
 }
 
 output "secret_access_key" {
-  value       = aws_iam_access_key.default.secret
+  value       = aws_iam_access_key.default.0.secret
   description = "The secret access key"
 }
 
 output "ssm_access_key_id" {
-  value       = aws_ssm_parameter.access_key_id.name
+  value       = aws_ssm_parameter.access_key_id.0.name
   description = "The SSM access key ID parameter name"
 }
 
 output "ssm_secret_access_key" {
-  value       = aws_ssm_parameter.secret_access_key.name
+  value       = aws_ssm_parameter.secret_access_key.0.name
   description = "The SSM secret access key parameter name"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   description = "The name of the user"
 }
 
+variable "create_user" {
+  type        = bool
+  default     = true
+  description = "Whether or not to create the AWS user and associated resources"
+}
+
 variable "policy" {
   type        = string
   default     = null


### PR DESCRIPTION
[Like the terraform-github-mcaf-repository](https://github.com/schubergphilis/terraform-github-mcaf-repository/blob/master/variables.tf#L1-L5) we need to provide a `create` variable so that we can optionally skip creating the AWS user in the `terraform-aws-mcaf-workspace` module