### PR TITLE
Append 'User' instead of 'Account'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_iam_user" "default" {
-  name = "${var.name}${var.postfix ? "Account" : ""}"
+  name = "${var.name}${var.postfix ? "User" : ""}"
   tags = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_iam_user_policy_attachment" "default" {
 }
 
 resource "aws_ssm_parameter" "access_key_id" {
-  name   = "/${lower(var.name)}account/credentials/access_key_id"
+  name   = "/${lower(var.name)}${var.postfix ? "user" : ""}/credentials/access_key_id"
   type   = "SecureString"
   value  = aws_iam_access_key.default.id
   key_id = var.kms_key_id
@@ -34,7 +34,7 @@ resource "aws_ssm_parameter" "access_key_id" {
 }
 
 resource "aws_ssm_parameter" "secret_access_key" {
-  name   = "/${lower(var.name)}account/credentials/secret_access_key"
+  name   = "/${lower(var.name)}${var.postfix ? "user" : ""}/credentials/secret_access_key"
   type   = "SecureString"
   value  = aws_iam_access_key.default.secret
   key_id = var.kms_key_id

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "kms_key_id" {
 variable "postfix" {
   type        = bool
   default     = true
-  description = "Postfix the user and policy names with Account and Policy"
+  description = "Postfix the user and policy names with User and Policy"
 }
 
 variable "tags" {


### PR DESCRIPTION
'User' is more inline with AWS terminology and matches how the Terraform resources are called while 'Account' refers to the actual AWS account.