### PR TITLE
Revert "Makes tags optional so you can use default_tags (Fixes: Error: "tags" are identical to those in the "default_tags" configuration block of the provider: please de-duplicate and try again" Discussed it is better to set the tags to null when using this module

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,5 @@ variable "postfix" {
 
 variable "tags" {
   type        = map(string)
-  default     = null
   description = "A mapping of tags to assign to the user"
 }


### PR DESCRIPTION
This reverts commit 06b7591ee8f7f5762395e6d0256c5346dcc4a164.