### PR TITLE
Remove invalid characters from SSM param name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   create_policy = var.create_policy != null ? var.create_policy : var.policy != null
+  ssm_name      = replace(var.name, "@", "_")
 }
 
 resource "aws_iam_user" "default" {
@@ -26,7 +27,7 @@ resource "aws_iam_user_policy_attachment" "default" {
 }
 
 resource "aws_ssm_parameter" "access_key_id" {
-  name   = "/${lower(var.name)}${var.postfix ? "account" : ""}/credentials/access_key_id"
+  name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/access_key_id"
   type   = "SecureString"
   value  = aws_iam_access_key.default.id
   key_id = var.kms_key_id
@@ -34,7 +35,7 @@ resource "aws_ssm_parameter" "access_key_id" {
 }
 
 resource "aws_ssm_parameter" "secret_access_key" {
-  name   = "/${lower(var.name)}${var.postfix ? "account" : ""}/credentials/secret_access_key"
+  name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/secret_access_key"
   type   = "SecureString"
   value  = aws_iam_access_key.default.secret
   key_id = var.kms_key_id
@@ -43,7 +44,7 @@ resource "aws_ssm_parameter" "secret_access_key" {
 
 resource "aws_ssm_parameter" "ses_smtp_password_v4" {
   count  = var.ssm_ses_smtp_password_v4 ? 1 : 0
-  name   = "/${lower(var.name)}${var.postfix ? "account" : ""}/credentials/ses_smtp_password_v4"
+  name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/ses_smtp_password_v4"
   type   = "SecureString"
   value  = aws_iam_access_key.default.ses_smtp_password_v4
   key_id = var.kms_key_id


### PR DESCRIPTION
Replaces invalid characters with `_`.
