### PR TITLE
create group when a user is created.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  create_policy = var.create_policy ? var.create_policy : var.policy != null
-  groups        = var.create_policy ? setunion(var.groups, [aws_iam_group.default[0].name]) : var.groups
+  create_policy = var.create_policy != null ? var.create_policy : var.policy != null
+  groups        = local.create_policy ? setunion(var.groups, [aws_iam_group.default[0].name]) : var.groups
   ssm_name      = replace(var.name, "@", "_")
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "name" {
 
 variable "create_policy" {
   type        = bool
-  default     = false
+  default     = null
   description = "Overrule whether the user role policy has to be created"
 }
 


### PR DESCRIPTION
AWS Config rule: iam-user-no-policies-check

By default, IAM users, groups, and roles have no access to AWS resources. IAM policies are how privileges are granted to users, groups, or roles.

Security Hub recommends that you apply IAM policies directly to groups and roles but not users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity might in turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.