### PR TITLE
Fix group attachment when not adding a group with the group variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   create_policy = var.create_policy != null ? var.create_policy : var.policy != null
-  groups        = local.create_policy ? setunion(var.groups, [aws_iam_group.default[0].name]) : var.groups
+  groups        = local.create_policy ? setunion(var.groups, [aws_iam_group.default[0].name]) : [aws_iam_group.default[0].name]
   ssm_name      = replace(var.name, "@", "_")
 }
 


### PR DESCRIPTION
- When not passing a custom policy via `var.policy` but only passing a `policy_arn`, the result of the `local.group` is an empty list while this should be a list containing the iam group.