### PR TITLE
Use aquasecurity/tfsec-pr-commenter-action as tfsec action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,10 +40,17 @@ jobs:
         continue-on-error: true # added this to prevent a PR from a remote fork failing the workflow
 
   tfsec:
-    name: tfsec
+    name: tfsec PR commenter
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Check out code
         uses: actions/checkout@master
-      - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+      - name: tfsec
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
+        with:
+          github_token: ${{ github.token }}

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,10 @@ resource "aws_iam_access_key" "default" {
   user = aws_iam_user.default.name
 }
 
+// Our IAM users are not real users so not going to have MFA configured. Real users
+// should instead use AWS SSO and assume a role.
+//
+// tfsec:ignore:aws-iam-enforce-group-mfa
 resource "aws_iam_group" "default" {
   count = local.create_policy || length(var.policy_arns) > 0 ? 1 : 0
   name  = "${var.name}${var.postfix ? "Group" : ""}"


### PR DESCRIPTION
- Fix findings in tfsec v1.28.1
- Use aquasecurity/tfsec-pr-commenter-action as tfsec action
