### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.13.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -57,6 +57,7 @@ No modules.
 | <a name="input_policy"></a> [policy](#input\_policy) | The policy to attach to the user. | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | A set of policy ARNs to attach to the user. | `set(string)` | `[]` | no |
 | <a name="input_postfix"></a> [postfix](#input\_postfix) | Postfix the user, policy and group names with Account, Policy and Group. | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_ssm_ses_smtp_password_v4"></a> [ssm\_ses\_smtp\_password\_v4](#input\_ssm\_ses\_smtp\_password\_v4) | Store the user's SES SMTP password in the SSM Parameter Store. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the user. | `map(string)` | `null` | no |
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ resource "aws_iam_user_group_membership" "default" {
 resource "aws_ssm_parameter" "access_key_id" {
   count = var.create_iam_access_key ? 1 : 0
 
+  region = var.region
   name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/access_key_id"
   key_id = var.kms_key_id
   type   = "SecureString"
@@ -61,6 +62,7 @@ resource "aws_ssm_parameter" "access_key_id" {
 resource "aws_ssm_parameter" "secret_access_key" {
   count = var.create_iam_access_key ? 1 : 0
 
+  region = var.region
   name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/secret_access_key"
   key_id = var.kms_key_id
   type   = "SecureString"
@@ -71,6 +73,7 @@ resource "aws_ssm_parameter" "secret_access_key" {
 resource "aws_ssm_parameter" "ses_smtp_password_v4" {
   count = var.create_iam_access_key && var.ssm_ses_smtp_password_v4 ? 1 : 0
 
+  region = var.region
   name   = "/${lower(local.ssm_name)}${var.postfix ? "account" : ""}/credentials/ses_smtp_password_v4"
   key_id = var.kms_key_id
   type   = "SecureString"

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,12 @@ output "name" {
   description = "The user name"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 output "secret_access_key" {
   value       = try(aws_iam_access_key.default[0].secret, "")
   description = "The secret access key"

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.13.0"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF User Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all related resources (SSM Parameters), which improves multi-region compatibility and control. The AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the SSM Parameters. If omitted, the default provider region is used.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
